### PR TITLE
Added API for unreviewed order number.

### DIFF
--- a/src/main/java/com/parasoft/demoapp/controller/OrderControllerExtra.java
+++ b/src/main/java/com/parasoft/demoapp/controller/OrderControllerExtra.java
@@ -1,0 +1,47 @@
+package com.parasoft.demoapp.controller;
+
+import com.parasoft.demoapp.dto.UnreviewedOrderNumberResponseDTO;
+import com.parasoft.demoapp.service.OrderServiceExtra;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Tag(name = "orders")
+@Controller
+@RequestMapping(value = {"/v1/orders", "/proxy/v1/orders"}, produces = MediaType.APPLICATION_JSON_VALUE)
+public class OrderControllerExtra {
+
+    @Autowired
+    private OrderServiceExtra orderServiceExtra;
+
+    @Operation(description = "Obtain the number of unreviewed order.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200",
+                    description = "The number of unreviewed order got successfully."),
+            @ApiResponse(responseCode = "401",
+                    description = "You are not authorized to get the unreviewed order number.",
+                    content = {@Content(schema = @Schema(hidden = true)) }),
+    })
+    @GetMapping("/unreviewedNumber")
+    @ResponseBody
+    public ResponseResult<UnreviewedOrderNumberResponseDTO> unreviewedOrderNumber() {
+
+        ResponseResult<UnreviewedOrderNumberResponseDTO> response = ResponseResult.getInstance(ResponseResult.STATUS_OK,
+                ResponseResult.MESSAGE_OK);
+
+        UnreviewedOrderNumberResponseDTO result = orderServiceExtra.getUnreviewedOrderNumber();
+
+        response.setData(result);
+
+        return response;
+    }
+}

--- a/src/main/java/com/parasoft/demoapp/dto/UnreviewedOrderNumberResponseDTO.java
+++ b/src/main/java/com/parasoft/demoapp/dto/UnreviewedOrderNumberResponseDTO.java
@@ -1,0 +1,14 @@
+package com.parasoft.demoapp.dto;
+
+import lombok.Data;
+
+@Data
+public class UnreviewedOrderNumberResponseDTO {
+    int unreviewedByApprover;
+    int unreviewedByPurchaser;
+
+    public UnreviewedOrderNumberResponseDTO(int unreviewedByApprover, int unreviewedByPurchaserOrderNumber) {
+        this.unreviewedByApprover = unreviewedByApprover;
+        this.unreviewedByPurchaser = unreviewedByPurchaserOrderNumber;
+    }
+}

--- a/src/main/java/com/parasoft/demoapp/repository/industry/OrderRepository.java
+++ b/src/main/java/com/parasoft/demoapp/repository/industry/OrderRepository.java
@@ -15,4 +15,8 @@ public interface OrderRepository extends JpaRepository<OrderEntity, Long> {
 	List<OrderEntity> findAllByRequestedBy(String requestedBy);
 
     Page<OrderEntity> findAllByRequestedBy(String requestedBy, Pageable pageable);
+
+    int countByReviewedByPRCH(boolean b);
+
+    int countByReviewedByAPV(boolean b);
 }

--- a/src/main/java/com/parasoft/demoapp/service/OrderServiceExtra.java
+++ b/src/main/java/com/parasoft/demoapp/service/OrderServiceExtra.java
@@ -1,0 +1,21 @@
+package com.parasoft.demoapp.service;
+
+import com.parasoft.demoapp.dto.UnreviewedOrderNumberResponseDTO;
+import com.parasoft.demoapp.repository.industry.OrderRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class OrderServiceExtra {
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    public UnreviewedOrderNumberResponseDTO getUnreviewedOrderNumber() {
+        int unreviewedByPurchaserOrderNumber = orderRepository.countByReviewedByPRCH(false);
+        int unreviewedByApproverOrderNumber = orderRepository.countByReviewedByAPV(false);
+        return new UnreviewedOrderNumberResponseDTO(unreviewedByApproverOrderNumber, unreviewedByPurchaserOrderNumber);
+    }
+}

--- a/src/main/resources/static/common/js/common.js
+++ b/src/main/resources/static/common/js/common.js
@@ -585,22 +585,11 @@ function getUnreviewedAmount($http,$rootScope,$filter){
     setTimeout(function(){
         $http({
             method: 'GET',
-            url: '/proxy/v1/orders'
+            url: '/proxy/v1/orders/unreviewedNumber'
         }).then(function(result) {
-            var orders = result.data.data.content;
-            var unreviewedNumByPRCH = 0;
-            var unreviewedNumByAPV = 0;
-
-            $.each(orders,function(i,order){
-                if(!order.reviewedByPRCH){
-                    unreviewedNumByPRCH += 1;
-                }else if(!order.reviewedByAPV){
-                    unreviewedNumByAPV += 1;
-                }
-            });
-
-            $rootScope.unreviewedNumByPRCH = unreviewedNumByPRCH;
-            $rootScope.unreviewedNumByAPV = unreviewedNumByAPV;
+            const numbers = result.data.data;
+            $rootScope.unreviewedNumByPRCH = numbers.unreviewedByPurchaser;
+            $rootScope.unreviewedNumByAPV = numbers.unreviewedByApprover;
         }).catch(function(result) {
             console.log(result);
             $rootScope.unreviewedNumByPRCH = 0;


### PR DESCRIPTION
The changes of this pull request is for TIA.
 * For opening purchaser home page, it will reach the `OrderController.java`, `OrderService.java` and `OrderEntity.java` since the API GET `/v1/orders` is called in the page.
 * So to aviod calling GET `/v1/orders`, I create another API GET `/v1/orders/unreviewedNumber` to avoid to reaching OrderController.java, OrderService.java and OrderEntity.java.
 * And we must isolate the logic code of GET `/v1/orders/unreviewedNumber` form `OrderController.java`, `OrderService.java` and `OrderEntity.java` since TIA calulates the impact tests by modified class, so I create three aditional java files `OrderControllerExtra.java`, `OrderServiceExtra.java` and `UnreviewedOrderNumberResponseDTO.java`.
.