### PR TITLE
Add gradle property to get cleaner console output

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.console=plain


### PR DESCRIPTION
The idea here is to prevent displaying verbose output when I run ./gradlew bootRun in CMD.
Let me know if this change will cause missing necessary information printed.
If this will be merged, let's confirm the job to pull changes to selenium-demo branch would work.