### PR TITLE
@task PDA-1229 Configured proxy for GraphQL

### DIFF
--- a/src/main/java/com/parasoft/demoapp/config/endpoint/ZuulConfig.java
+++ b/src/main/java/com/parasoft/demoapp/config/endpoint/ZuulConfig.java
@@ -1,6 +1,7 @@
 package com.parasoft.demoapp.config.endpoint;
 
 import com.parasoft.demoapp.service.GlobalPreferencesDefaultSettingsService;
+import com.parasoft.demoapp.service.GlobalPreferencesService;
 import com.parasoft.demoapp.service.RestEndpointService;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
@@ -15,9 +16,10 @@ public class ZuulConfig {
     @Bean
     @DependsOn("defaultDataInitialization")
     public CustomRouteLocator routeLocator(RestEndpointService restEndpointService,
-                                           GlobalPreferencesDefaultSettingsService defaultGlobalPreferencesSettingsService) {
+                                           GlobalPreferencesDefaultSettingsService defaultGlobalPreferencesSettingsService,
+                                           GlobalPreferencesService globalPreferencesService) {
 
         return new CustomRouteLocator("/", new ZuulProperties(), restEndpointService,
-                                        defaultGlobalPreferencesSettingsService);
+                                        defaultGlobalPreferencesSettingsService, globalPreferencesService);
     }
 }

--- a/src/main/java/com/parasoft/demoapp/service/GlobalPreferencesDefaultSettingsService.java
+++ b/src/main/java/com/parasoft/demoapp/service/GlobalPreferencesDefaultSettingsService.java
@@ -19,7 +19,9 @@ public class GlobalPreferencesDefaultSettingsService {
 
     public static final String HOST_WITHOUT_PORT = "http://localhost:";
 
-    public static final String GRAPHQL_ENDPOINT_PATH = "/graphql";
+    public static final String GRAPHQL_ENDPOINT_ID = "graphql";
+    public static final String GRAPHQL_ENDPOINT_PATH = "/proxy/graphql/**";
+    public static final String GRAPHQL_ENDPOINT_REAL_PATH = "/graphql";
 
     public static final String CATEGORIES_ENDPOINT_ID = "categories";
     public static final String CATEGORIES_ENDPOINT_PATH = "/proxy/v1/assets/categories/**";
@@ -158,7 +160,7 @@ public class GlobalPreferencesDefaultSettingsService {
     }
 
     public String defaultGraphQLEndpoint() {
-        return HOST_WITHOUT_PORT + webConfig.getServerPort() + GRAPHQL_ENDPOINT_PATH;
+        return HOST_WITHOUT_PORT + webConfig.getServerPort() + GRAPHQL_ENDPOINT_REAL_PATH;
     }
 
     public boolean defaultAdvertisingEnabled(){


### PR DESCRIPTION
For verification of this configuration, I have combined the UI implementation of [yshi_graphQL](https://github.com/parasoft/parasoft-demo-app/compare/yshi_graphQL ) with message proxy in Virtualize.

After this configuration, we can use "/proxy/graphql" instead of "/grahql" in JS files.